### PR TITLE
Format and f-string support (and minor other changes)

### DIFF
--- a/build-android.xml
+++ b/build-android.xml
@@ -17,6 +17,14 @@
   <fail message="sdk.dir is missing. Make sure to generate local.properties using 'android update project' or to inject it through the ANDROID_HOME environment variable."
         unless="sdk.dir" />
 
+  <fail message="android.jar not found at ${sdk.dir}/platforms/${target.platform}/, is your ANDROID_TARGET set?">
+    <condition>
+        <not>
+          <available file="${sdk.dir}/platforms/${target.platform}/android.jar"/>
+        </not>
+    </condition>
+  </fail>
+
   <target name="compile" description="Compile the Android-specific source">
     <mkdir dir="${build}/android"/>
     <javac debug="true"

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -786,7 +786,7 @@ public class Python {
     )
     public static org.python.types.Str format(org.python.Object value, org.python.Object format_spec) {
         if (format_spec == null) {
-            return (org.python.types.Str) value.__str__();
+			return (org.python.types.Str) value.__format__(new org.python.types.Str(""));
         } else {
             return (org.python.types.Str) value.__format__(format_spec);
         }

--- a/python/common/org/python/Object.java
+++ b/python/common/org/python/Object.java
@@ -48,7 +48,7 @@ public interface Object extends Comparable {
     public org.python.Object __str__();
 
     public org.python.Object __bytes__();
-    public org.python.Object __format__(org.python.Object format);
+    public org.python.Object __format__(org.python.Object format_spec);
 
     public org.python.Object __lt__(org.python.Object other);
     public org.python.Object __le__(org.python.Object other);

--- a/python/common/org/python/types/Bool.java
+++ b/python/common/org/python/types/Bool.java
@@ -69,13 +69,6 @@ public class Bool extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = ""
-    )
-    public org.python.types.Str __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("'bool'.__format__ has not been implemented.");
-    }
-
-    @org.python.Method(
             __doc__ = "",
             args = {"index", "value"}
     )

--- a/python/common/org/python/types/ByteArray.java
+++ b/python/common/org/python/types/ByteArray.java
@@ -587,12 +587,6 @@ public class ByteArray extends org.python.types.Object {
         return new Bytes(this.value).__contains__(slice);
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytearray.__format__ has not been implemented.");
-    }
 
     @org.python.Method(
             __doc__ = ""

--- a/python/common/org/python/types/Bytes.java
+++ b/python/common/org/python/types/Bytes.java
@@ -251,12 +251,6 @@ public class Bytes extends org.python.types.Object {
         return org.python.types.Bool.FALSE;
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(java.util.List<org.python.Object> args, java.util.Map<java.lang.String, org.python.Object> kwargs, java.util.List<org.python.Object> default_args, java.util.Map<java.lang.String, org.python.Object> default_kwargs) {
-        throw new org.python.exceptions.NotImplementedError("bytes.__format__ has not been implemented.");
-    }
 
     @org.python.Method(
             __doc__ = "Return self>=value.",

--- a/python/common/org/python/types/Complex.java
+++ b/python/common/org/python/types/Complex.java
@@ -161,39 +161,49 @@ public class Complex extends org.python.types.Object {
             __doc__ = "Return repr(self)."
     )
     public org.python.Object __repr__() {
-        java.lang.StringBuilder buffer = new java.lang.StringBuilder();
-        boolean real_present = true;
-        if (this.real.value != 0) {
-            buffer.append("(");
-            if (((org.python.types.Bool) ((this.real).__int__().__eq__(this.real))).value) {
-                buffer.append(((org.python.types.Str) this.real.__int__().__repr__()).value);
-            } else {
-                buffer.append(((org.python.types.Str) this.real.__repr__()).value);
-            }
+
+        if (this.real.value != 0.0 || this.real.isNegativeZero()) {
+            return new org.python.types.Str("(" + partToStr(this.real) + ((this.imag.value >= 0.0 && !this.imag.isNegativeZero()) ? "+" : "-") + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
         } else {
-            real_present = false;
+            return new org.python.types.Str(partToStr(this.imag) + "j");
         }
-        if (this.real.value != 0 && this.imag.value >= 0) {
-            buffer.append("+");
-        }
-        if (((org.python.types.Bool) ((this.imag).__int__().__eq__(this.imag))).value) {
-            buffer.append(((org.python.types.Str) (this.imag).__int__().__repr__()).value);
-        } else {
-            buffer.append(((org.python.types.Str) (this.imag).__repr__()).value);
-        }
-        buffer.append("j");
-        if (real_present) {
-            buffer.append(")");
-        }
-        return new org.python.types.Str(buffer.toString());
+
     }
 
+
     @org.python.Method(
-            __doc__ = "complex.__format__() -> str\n\nConvert to a string according to format_spec."
+					   __doc__ = "complex.__format__() -> str\n\nConvert to a string according to format_spec.",
+					   args={"format_spec"}
     )
-    public org.python.Object __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("complex.__format__ has not been implemented.");
-    }
+    public org.python.Object __format__(org.python.Object format_spec) {
+		String fs = ((org.python.types.Str) format_spec).value;
+
+
+		if(!(fs.endsWith("f")
+			 ||fs.endsWith("F")
+			 ||fs.endsWith("g")
+			 ||fs.endsWith("G")
+			 ||fs.endsWith("e")
+			 ||fs.endsWith("E")
+         	 ||fs.endsWith("n")
+			 )){
+			//format specs are ignored by python for complex numbers if no floatingpoit spec is present
+			return this.__repr__();
+		}
+		// use the floating point spec
+
+        java.lang.StringBuilder buffer = new java.lang.StringBuilder();
+
+		buffer.append(((org.python.types.Str) this.real.__format__(format_spec)).value);
+
+        if (this.imag.value >= 0) {
+            buffer.append("+");
+        }
+		buffer.append(((org.python.types.Str) (this.imag).__format__(format_spec)).value);
+        buffer.append("j");
+        return new org.python.types.Str(buffer.toString());
+
+	}
 
     @org.python.Method(
             __doc__ = "Return self<value.",
@@ -302,16 +312,6 @@ public class Complex extends org.python.types.Object {
         throw new org.python.exceptions.TypeError("unsupported operand type(s) for -: 'complex' and '" + other.typeName() + "'");
     }
 
-    @org.python.Method(
-            __doc__ = "Return str(self)."
-    )
-    public org.python.Object __str__() {
-        if (this.real.value != 0.0 || this.real.isNegativeZero()) {
-            return new org.python.types.Str("(" + partToStr(this.real) + ((this.imag.value >= 0.0 && !this.imag.isNegativeZero()) ? "+" : "-") + partToStr(new org.python.types.Float(Math.abs(this.imag.value))) + "j)");
-        } else {
-            return new org.python.types.Str(partToStr(this.imag) + "j");
-        }
-    }
 
     @org.python.Method(
             __doc__ = "Return self*value.",

--- a/python/common/org/python/types/Dict.java
+++ b/python/common/org/python/types/Dict.java
@@ -136,13 +136,6 @@ public class Dict extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError("dict.__format__() has not been implemented.");
-    }
-
-    @org.python.Method(
             __doc__ = ""
     )
     public org.python.Object __bool__() {

--- a/python/common/org/python/types/DictKeys.java
+++ b/python/common/org/python/types/DictKeys.java
@@ -56,12 +56,6 @@ public class DictKeys extends org.python.types.FrozenSet {
         return new org.python.types.Str(buffer.toString());
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError(this.typeName() + ".__format__() has not been implemented.");
-    }
 
     @org.python.Method(
             __doc__ = "__dir__() -> list\ndefault dir() implementation"

--- a/python/common/org/python/types/DictValues.java
+++ b/python/common/org/python/types/DictValues.java
@@ -48,13 +48,6 @@ public class DictValues extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(org.python.Object other) {
-        throw new org.python.exceptions.NotImplementedError(this.typeName() + ".__format__() has not been implemented.");
-    }
-
-    @org.python.Method(
             __doc__ = "__dir__() -> list\ndefault dir() implementation"
     )
     public org.python.types.List __dir__() {

--- a/python/common/org/python/types/Int.java
+++ b/python/common/org/python/types/Int.java
@@ -1,5 +1,7 @@
 package org.python.types;
 
+import java.util.Locale;
+
 public class Int extends org.python.types.Object {
     public long value;
 
@@ -128,10 +130,24 @@ public class Int extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = ""
+					   __doc__ = "",
+					   args = {"format_spec"}
     )
-    public org.python.types.Str __format__(org.python.Object format_str) {
-        throw new org.python.exceptions.NotImplementedError("int.__format__() has not been implemented");
+    public org.python.types.Str __format__(org.python.Object format_spec) {
+
+		String fs = ((org.python.types.Str) format_spec).value;
+		if(fs.endsWith("n"))
+			throw new org.python.exceptions.NotImplementedError("int formatting with 'n' as formatter has not been implemented");
+		if(fs.endsWith("b"))
+			throw new org.python.exceptions.NotImplementedError("int formatting with 'b' as formatter has not been implemented");
+
+		if(fs.length() == 0 || !Character.isLetter(fs.charAt(fs.length()-1))){
+			// use d as default formatter
+			fs += "d";
+		}
+
+
+		return new org.python.types.Str(String.format(Locale.US,"%"+fs,this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/List.java
+++ b/python/common/org/python/types/List.java
@@ -154,13 +154,6 @@ public class List extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__() {
-        throw new org.python.exceptions.NotImplementedError("list.__format__() has not been implemented.");
-    }
-
-    @org.python.Method(
             __doc__ = "Return self<value.",
             args = {"other"}
     )

--- a/python/common/org/python/types/Object.java
+++ b/python/common/org/python/types/Object.java
@@ -172,11 +172,15 @@ public class Object extends java.lang.RuntimeException implements org.python.Obj
 
     @org.python.Method(
             __doc__ = "default object formatter",
-            args = {"format_string"}
+            args = {"format_spec"}
     )
-    public org.python.Object __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("'" + this.typeName() + ".__format__' has not been implemented");
-    }
+    public org.python.Object __format__(org.python.Object format_spec) {
+		if( format_spec != null &&
+			((org.python.types.Str) format_spec).value != ""){
+			throw new org.python.exceptions.TypeError("on-empty format string passed to object.__format__");
+		}
+		return this.__str__();
+	}
 
     @org.python.Method(
             __doc__ = "Return self<value.",

--- a/python/common/org/python/types/Set.java
+++ b/python/common/org/python/types/Set.java
@@ -102,12 +102,6 @@ public class Set extends org.python.types.Object {
         return new org.python.types.Str(buffer.toString());
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("__format__() has not been implemented");
-    }
 
     @org.python.Method(
             __doc__ = "",

--- a/python/common/org/python/types/Str.java
+++ b/python/common/org/python/types/Str.java
@@ -139,10 +139,14 @@ public class Str extends org.python.types.Object {
     }
 
     @org.python.Method(
-            __doc__ = "S.__format__(format_spec) -> str\n\nReturn a formatted version of S as described by format_spec."
+					   __doc__ = "S.__format__(format_spec) -> str\n\nReturn a formatted version of S as described by format_spec.",
+					   args = {"format_spec"}
     )
-    public org.python.Object __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("__format__() has not been implemented.");
+    public org.python.Object __format__(org.python.Object format_spec) {
+		String fs = ((org.python.types.Str) format_spec).value;
+		if(!fs.endsWith("s"))
+			fs += "s";
+		return new org.python.types.Str(String.format("%"+fs,this.value));
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Super.java
+++ b/python/common/org/python/types/Super.java
@@ -120,12 +120,12 @@ public class Super implements org.python.Object {
         throw new org.python.exceptions.AttributeError(this, "__bytes__");
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter",
-            args = {"format_string"}
+	@org.python.Method(
+					   __doc__ = "",
+					   args = {"format_spec"}
     )
-    public org.python.Object __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("'super().__format__' has not been implemented");
+    public org.python.Object __format__(org.python.Object format_spec) {
+		return this.__str__();
     }
 
     @org.python.Method(

--- a/python/common/org/python/types/Tuple.java
+++ b/python/common/org/python/types/Tuple.java
@@ -84,12 +84,6 @@ public class Tuple extends org.python.types.Object {
         return new org.python.types.Str(buffer.toString());
     }
 
-    @org.python.Method(
-            __doc__ = "default object formatter"
-    )
-    public org.python.types.Str __format__(org.python.Object format_string) {
-        throw new org.python.exceptions.NotImplementedError("__format__() has not been implemented.");
-    }
 
     @org.python.Method(
             __doc__ = ""

--- a/voc/python/ast.py
+++ b/voc/python/ast.py
@@ -99,7 +99,7 @@ class NameVisitor(ast.NodeVisitor):
 class LocalsVisitor(ast.NodeVisitor):
     def __init__(self, context):
         self.context = context
-        
+
     def visit_Name(self, node):
         if type(node.ctx) == ast.Store:
             if node.id not in self.context.local_vars:
@@ -189,18 +189,15 @@ class Visitor(ast.NodeVisitor):
                         return
                     index += 1
 
-
-    def generic_visit(self,node):
+    def generic_visit(self, node):
         # Catches node types that are not implemented
         # Expr calls this function directly and is meant to do so
         # Other node types mean that we are skipping something that we should not
         if type(node) != _ast.Expr:
             raise TypeError("Not translating node of type "+str(type(node)))
         super().generic_visit(node)
-        
-                    
-    def visit(self, node):
 
+    def visit(self, node):
         try:
             self.parse_yield(node)
             if id(node) in self.resolved_yield_expression.keys():
@@ -1808,7 +1805,7 @@ class Visitor(ast.NodeVisitor):
                         'Lorg/python/Object;'
                     )
                 )
-                
+
         yield_point = len(self.context.yield_points) + 1
 
         # Save the current stack and yield index
@@ -2267,8 +2264,6 @@ class Visitor(ast.NodeVisitor):
     def visit_Str(self, node):
         self.context.add_str(node.s)
 
-
-        
     @node_visitor
     def visit_Bytes(self, node):
         self.context.add_opcodes(
@@ -2488,7 +2483,6 @@ class Visitor(ast.NodeVisitor):
     def visit_JoinedStr(self, node):
         # Joined strs are new in python 3.6+ and are used in fstrings.
         # The easyiest way to handle them seems to be to transform them to "".join(*values)
-        
         transformed_node = _ast.Call(
                 lineno=node.lineno,
                 col_offset=node.col_offset,
@@ -2509,7 +2503,7 @@ class Visitor(ast.NodeVisitor):
                 ],
                 keywords=[],
             )
-        # pass on the handeling
+        # pass on the handling
         self.visit(transformed_node)
 
     @node_visitor
@@ -2548,7 +2542,7 @@ class Visitor(ast.NodeVisitor):
         else:
             raise ValueError("Conversion type %i not implemented for f-strings" % node.conversion)
 
-        formatspec =  node.format_spec or _ast.Str(lineno=node.lineno, col_offset=node.col_offset, s="")
+        formatspec = node.format_spec or _ast.Str(lineno=node.lineno, col_offset=node.col_offset, s="")
         transformed_node = _ast.Call(lineno=node.lineno,
                                      col_offset=node.col_offset,
                                      func=_ast.Attribute(
@@ -2560,10 +2554,9 @@ class Visitor(ast.NodeVisitor):
                                      ),
                                      args=[formatspec],
                                      keywords=[],
-        )
+                                     )
         self.visit(transformed_node)
 
-        
     @node_visitor
     def visit_Index(self, node):
         self.visit(node.value)


### PR DESCRIPTION
Major additions
- Implements `format()` as per python standard
- Implements standard `__format__` for all objects
- Implements `__format__` for `Str`, `Float`, `Int` and `Complex`
- Fixes `__repr__` for `Complex` by using the already present code from the `__str__` method instead.
- `__repr__` uses `__format__` for float type
- Implements f-strings by manipulating the AST.

Small changes:
- Added `generic_visit` to `ast.py`. Unimplemented node types previously where ignored but now give an error.
- Added a fail in `build-android.xml` when `android.jar` is not found