### PR TITLE
Be explicit about python3

### DIFF
--- a/build-android.xml
+++ b/build-android.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="python" default="dist">
+<project name="python3" default="dist">
 
   <!-- if sdk.dir was not set from one of the property file, then
        get it from the ANDROID_HOME env var.
@@ -30,7 +30,7 @@
       <classpath path="${sdk.dir}/platforms/${target.platform}/android.jar" />
     </javac>
 
-    <exec executable="python">
+    <exec executable="python3">
       <arg value="tools/compile_stdlib.py"/>
       <arg value="--fast"/>
       <arg value="android"/>

--- a/build-java.xml
+++ b/build-java.xml
@@ -1,4 +1,4 @@
-<project name="python" default="dist" basedir=".">
+<project name="python3" default="dist" basedir=".">
   <description>
     Build Python support libraries for voc
   </description>
@@ -15,7 +15,7 @@
   </target>
 
   <target name="compile_stdlib" description="Compile the standard library">
-    <exec executable="python">
+    <exec executable="python3">
       <arg value="tools/compile_stdlib.py"/>
       <arg value="--fast"/>
       <arg value="java"/>


### PR DESCRIPTION
Some Linux distributions will use `python3` not `python` for Python 3 scripts. We should use that instead of assuming that `python` is now Python 3.