### PR TITLE
Exclude a test module from being built

### DIFF
--- a/tools/compile_stdlib.py
+++ b/tools/compile_stdlib.py
@@ -115,6 +115,7 @@ KNOWN_PROBLEM_MODULES = set([
 IGNORE_MODULES = set([
     '__builtins__',
     '__init__',
+    '__phello__.foo',
     'plat-aix4',
     'plat-darwin',
     'plat-freebsd4',


### PR DESCRIPTION
The `__phello__.foo` module from Ouroboros breaks jar->dex conversion.