### PR TITLE
Change most remaining 'PyBee' references to 'BeeWare'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-PyBee <3's contributions!
+BeeWare <3's contributions!
 
-Please be aware, PyBee operates under a Code of Conduct.
+Please be aware, BeeWare operates under a Code of Conduct.
 
-See [CONTRIBUTING to PyBee](http://pybee.org/contributing) for details.
+See [CONTRIBUTING to BeeWare](https://beeware.org/contributing) for details.

--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,13 @@ VOC
     :target: https://pypi.python.org/pypi/voc
 
 .. image:: https://img.shields.io/pypi/l/voc.svg
-    :target: https://github.com/pybee/voc/blob/master/LICENSE
+    :target: https://github.com/beeware/voc/blob/master/LICENSE
 
 .. image:: https://beekeeper.herokuapp.com/projects/pybee/voc/shield
     :target: https://beekeeper.herokuapp.com/projects/pybee/voc
 
-.. image:: https://badges.gitter.im/pybee/general.svg
-    :target: https://gitter.im/pybee/general
+.. image:: https://badges.gitter.im/beeware/general.svg
+    :target: https://gitter.im/beeware/general
 
 A transpiler that converts Python code into Java bytecode.
 
@@ -85,7 +85,7 @@ VOC is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 We foster a welcoming and respectful community as described in our
 `BeeWare Community Code of Conduct`_.
@@ -98,12 +98,12 @@ To get started with contributing to VOC, head over to our `First Timers Guide`_.
 If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: https://beeware.org
 .. _Read The Docs: https://voc.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
+.. _beeware/general: https://gitter.im/beeware/general
 .. _BeeWare Community Code of Conduct: https://beeware.org/community/behavior/
 .. _First Timers Guide: https://beeware.org/contributing/how/first-time/what/voc/
-.. _log them on Github: https://github.com/pybee/voc/issues
-.. _fork the code: https://github.com/pybee/voc
-.. _submit a pull request: https://github.com/pybee/voc/pulls
+.. _log them on Github: https://github.com/beeware/voc/issues
+.. _fork the code: https://github.com/beeware/voc
+.. _submit a pull request: https://github.com/beeware/voc/pulls

--- a/docs/background/community.rst
+++ b/docs/background/community.rst
@@ -9,7 +9,7 @@ VOC is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* `Our Gitter channel`_ for discussion about development and general help around this project or anything under the Beeware suite of projects. 
+* `Our Gitter channel`_ for discussion about development and general help around this project or anything under the BeeWare suite of projects.
 
 Code of Conduct
 ---------------
@@ -24,14 +24,14 @@ Contributing
 If you experience problems with VOC, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: https://beeware.org
 .. _Read The Docs: https://voc.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _Our Gitter channel: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/voc/issues
-.. _fork the code: https://github.com/pybee/voc
-.. _submit a pull request: https://github.com/pybee/voc/pulls
+.. _Our Gitter channel: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/voc/issues
+.. _fork the code: https://github.com/beeware/voc
+.. _submit a pull request: https://github.com/beeware/voc/pulls
 
-.. _Code of Conduct: https://pybee.org/community/behavior/code-of-conduct/
+.. _Code of Conduct: https://beeware.org/community/behavior/code-of-conduct/
 .. _Russell Keith-Magee: mailto:russell@keith-magee.com
-.. _First Timers Guide: http://pybee.org/contributing/how/first-time/what/voc/
+.. _First Timers Guide: https://voc.readthedocs.io/en/latest/how-to/contribute-code.html

--- a/docs/background/faq.rst
+++ b/docs/background/faq.rst
@@ -125,5 +125,5 @@ You can see `here an example TicTacToe app that does that <https://github.com/el
 
 
 .. _Vereenigde Oostindische Compagnie (VOC): https://en.wikipedia.org/wiki/Dutch_East_India_Company
-.. _toga: https://github.com/pybee/toga
-.. _toga-android: https://github.com/pybee/toga-android
+.. _toga: https://github.com/beeware/toga
+.. _toga-android: https://github.com/beeware/toga-android

--- a/docs/background/install.rst
+++ b/docs/background/install.rst
@@ -45,7 +45,7 @@ The first step is to create a project directory, and clone VOC:
 
     $ mkdir tutorial
     $ cd tutorial
-    $ git clone https://github.com/pybee/voc.git
+    $ git clone https://github.com/beeware/voc.git
 
 Then create a virtual environment and install VOC into it:
 

--- a/docs/how-to/development-env.rst
+++ b/docs/how-to/development-env.rst
@@ -3,7 +3,7 @@ Setting up your development environment
 
 The process of setting up a development environment is very similar to
 the :doc:`/background/install` process. The biggest difference is that
-instead of using the official PyBee repository, you'll be using your own
+instead of using the official BeeWare repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you

--- a/docs/how-to/release_process.rst
+++ b/docs/how-to/release_process.rst
@@ -33,7 +33,7 @@ others can benefit from the changes that have been made recently.
 
 5. When CI passes, merge.
 
-6. Update your checkout of the main ``pybee/voc`` repository
+6. Update your checkout of the main ``beeware/voc`` repository
 
 7. Tag the release. There is a version tag for VOC, plus tags for each
    of the support libraries that will be released::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,12 +86,12 @@ VOC is part of the `BeeWare suite`_. You can talk to the community through:
 
  * `@pybeeware on Twitter`_
 
- * `pybee/general on Gitter`_
+ * `beeware/general on Gitter`_
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: https://beeware.org
 .. _Read The Docs: https://voc.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general on Gitter: https://gitter.im/pybee/general
+.. _beeware/general on Gitter: https://gitter.im/beeware/general
 
 
 .. toctree::

--- a/docs/reference/differences.rst
+++ b/docs/reference/differences.rst
@@ -8,7 +8,7 @@ A ``StopIteration`` is a signal raised by an iterator to tell whomever is
 iterating that there are no more items to be produced. This is used in ``for``
 loops, generator functions, etc. The ``org.python.exception.StopIteration``
 exception differs from the CPython ``StopIteration`` exception in that it is a
-singleton. This was introduced in `PR #811<https://github.com/pybee/voc/pull/881>`_
+singleton. This was introduced in `PR #811<https://github.com/beeware/voc/pull/881>`_
 as part of a performance effort as it yields a non-trivial performance improvement
 for nested ``for`` loops. However, it also means that an equality comparison
 between two ``StopIteration`` exceptions will always be ``True``, which is not

--- a/python/common/org/Python.java
+++ b/python/common/org/Python.java
@@ -634,7 +634,7 @@ public class Python {
     )
     public static org.python.Object credits() {
         return new org.python.types.Str(
-                "voc is a BeeWare project. See pybee.org/voc for more information.\n" +
+                "voc is a BeeWare project. See beeware.org/voc for more information.\n" +
                         "\n" +
                         "Thanks to CWI, CNRI, BeOpen.com, Zope Corporation and a cast of thousands\n" +
                         "for supporting Python development.  See www.python.org for more information.\n"

--- a/python/common/org/python/exceptions/StopIteration.java
+++ b/python/common/org/python/exceptions/StopIteration.java
@@ -6,7 +6,7 @@ public class StopIteration extends org.python.exceptions.Exception {
 
     /**
      * StopIteration is a singleton instance for performance reasons, introduced in
-     * PR #881 (https://github.com/pybee/voc/pull/881/). This results in a non-trivial
+     * PR #881 (https://github.com/beeware/voc/pull/881/). This results in a non-trivial
      * performance improvement for nested loops. However, this also means that the equality
      * comparison between StopIteration instances will always be true.
      */

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/voc',
+    url='https://beeware.org/voc',
     packages=find_packages(exclude=['docs', 'tests']),
     python_requires='>=3.4',
     entry_points={
@@ -44,10 +44,10 @@ setup(
         'Topic :: Utilities',
     ],
     test_suite='tests',
-    package_urls={
-        'Funding': 'https://pybee.org/contributing/membership/',
+    project_urls={
+        'Funding': 'https://beeware.org/contributing/membership/',
         'Documentation': 'https://voc.readthedocs.io/en/latest/',
-        'Tracker': 'https://github.com/pybee/voc/issues',
-        'Source': 'https://github.com/pybee/voc',
+        'Tracker': 'https://github.com/beeware/voc/issues',
+        'Source': 'https://github.com/beeware/voc',
     },
 )

--- a/tools/compile_stdlib.py
+++ b/tools/compile_stdlib.py
@@ -190,7 +190,7 @@ def update_repo():
     try:
         if repo_folder is None:
             print('Cloning Ouroboros...')
-            git_cmd = ['git', 'clone', 'https://github.com/pybee/ouroboros.git']
+            git_cmd = ['git', 'clone', 'https://github.com/beeware/ouroboros.git']
             subprocess.Popen(
                 git_cmd,
                 cwd=os.path.dirname(REPO_ROOT)


### PR DESCRIPTION
The only places left that I could find 'pybee':
- In various test code
- `beekeeper.yml`
- Anytime the twitter account `@pybeeware` is mentioned
- https://beekeeper.herokuapp.com/projects/pybee/voc is referenced in `README.rst` (and it seems to be broken #957, fix is in #948)
- `tools/upload.py` contains the line `'pybee-briefcase-support',`